### PR TITLE
make qgis output on tty while testing

### DIFF
--- a/qgis_testrunner.sh
+++ b/qgis_testrunner.sh
@@ -7,7 +7,7 @@ TEST_NAME=$1
 
 cd /tests_directory
 echo "Running test $1 ..."
-OUTPUT=`unbuffer qgis --nologo --code /usr/bin/qgis_testrunner.py $TEST_NAME  2>/dev/null`
+OUTPUT=$(unbuffer qgis --nologo --code /usr/bin/qgis_testrunner.py $TEST_NAME  2>/dev/null | tee /dev/tty)
 EXIT_CODE="$?"
 if [ -z "$OUTPUT" ]; then
     echo "ERROR: no output from the test runner! (exit code: ${EXIT_CODE})"
@@ -17,7 +17,6 @@ echo $OUTPUT | grep -q FAILED
 IS_FAILED="$?"
 echo $OUTPUT | grep OK | grep -q 'Ran'
 IS_PASSED="$?"
-echo "$OUTPUT"
 echo "Finished running test $1."
 if [ "$IS_PASSED" -eq "0" ] && [ "$IS_FAILED" -eq "1" ]; then
     exit 0;


### PR DESCRIPTION
If the test suite takes more than 10 minutes, Travis will stop because of inactivity.
To make travis happy, we need to redirect the output to tty.
